### PR TITLE
[sim-exaple] correct comment syntax

### DIFF
--- a/dspace-jspui/src/main/webapp/sim-example.jsp
+++ b/dspace-jspui/src/main/webapp/sim-example.jsp
@@ -78,7 +78,7 @@
 		    <div class="panel-body">
 			<p>StatSpace brings together vetted open education materials for use across disciplines. Members of our community can <strong>search and use materials</strong> in the repository, <strong>contribute materials</strong> of their own, and <strong>evaluate materials</strong> they use.</p>
 			<label>Search StatSpace now:</label>
-			<%-- Search Box --%/>
+			<%-- Search Box --%>
 			<form method="get" action="<%= request.getContextPath() %>/simple-search">
 			    <div class="input-group">
 				<input type="text" class="form-control" placeholder="Enter keywords" name="query" id="tequery"/>


### PR DESCRIPTION
A back slash was present where if wasn't suppose to be