### PR TITLE
Added key-word pair and removed form questions

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -80,6 +80,7 @@ itemlist.thumbnail             = Preview
 
 itemlist.title.undefined	   = Undefined
 
+jsp.about.title													= About
 jsp.adminhelp                                                   = <span class="glyphicon glyphicon-question-sign"></span>
 jsp.administer                                                  = Administer
 jsp.admintools                                                  = Admin Tools

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -198,7 +198,7 @@
          <required></required>
        </field>
 
-       <!-- Audience level -->
+       <!-- Prerequisite Knowledge -->
        <field>
          <dc-schema>dcterms</dc-schema>
          <dc-element>audience</dc-element>
@@ -209,53 +209,9 @@
          <required></required>
        </field>  
        
-       <!-- University Acronym -->
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartof</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>University Acronym</label>
-         <input-type>onebox</input-type>
-         <hint>This is Optional</hint>
-         <required></required>
-       </field>
-         
-        <!-- Course Subject -->
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartof</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Course Subject</label>
-         <input-type>onebox</input-type>
-         <hint>This is Optional</hint>
-         <required></required>
-       </field>
-         
-        <!-- Course Number -->
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>relation</dc-element>
-         <dc-qualifier>ispartof</dc-qualifier>
-         <repeatable>true</repeatable>
-         <label>Course Number</label>
-         <input-type>onebox</input-type>
-         <hint>This is Optional</hint>
-         <required></required>
-       </field>
-         
-         
-        <!-- DOI -->
-       <field>
-         <dc-schema>dc</dc-schema>
-         <dc-element>identifier</dc-element>
-         <dc-qualifier></dc-qualifier>
-         <label>DOI</label>
-         <input-type>onebox</input-type>
-         <hint>The item's digital object identifier code, if available.</hint>
-         <required></required>
-       </field>
+       
+
+        
      </page>
 
    </form>


### PR DESCRIPTION
Added a line in messages.properties for jsp.about.title to load
correctly, required a word to load from.
Correctly labelled the "Prerequisite knowledge" input box for default input form.
Removed from the default statspace input form DOI, University Acronym,
Course Number and Course Subject.